### PR TITLE
Add readinessProbe to avoid port-forward error

### DIFF
--- a/manifests/asciiboot-pod.yaml
+++ b/manifests/asciiboot-pod.yaml
@@ -8,3 +8,7 @@ spec:
   containers:
     - image: asciiboot-dev:0.0.1-SNAPSHOT
       name: asciiboot
+      readinessProbe:
+        httpGet:
+          path: /actuator/health/readiness
+          port: 8080


### PR DESCRIPTION
The goal was to avoid skaffold  start mesage:

`port forwarding pod-asciiboot-default-8080 got terminated: output: error: unable to forward port because pod is not running. Current status=Pending`

However, it still ocurs from time to time.
